### PR TITLE
Updated postcss-import version.

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   ],
   "dependencies": {
     "postcss": "^5",
-    "postcss-import": "^5.2.2",
+    "postcss-import": "^7.1.3",
     "vow": "^0.4.9"
   },
   "peerDependencies": {


### PR DESCRIPTION
It need for to fix warn log - Container#eachAtRule is deprecated. Use Container#walkAtRules instead.
